### PR TITLE
community/knot-resolver: add lmdb-dev

### DIFF
--- a/community/knot-resolver/APKBUILD
+++ b/community/knot-resolver/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: tcely <knot-resolver+aports@tcely.33mail.com>
 pkgname=knot-resolver
 pkgver=3.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Minimalistic caching DNS resolver implementation"
 url="https://www.knot-resolver.cz/"
 # luajit is not available for disabled arches
@@ -14,7 +14,7 @@ depends="lua5.1-sec lua5.1-socket"
 depends_dnstap=""
 depends_dnstap_dev="fstrm-dev protobuf-c-dev"
 depends_http="$pkgname lua5.1-http"
-depends_dev="knot-dev>=2.8.0 libedit-dev libuv-dev luajit-dev $depends_dnstap_dev"
+depends_dev="knot-dev>=2.8.0 libedit-dev libuv-dev lmdb-dev luajit-dev $depends_dnstap_dev"
 makedepends="$depends_dev bash dnssec-root vim"
 checkdepends="cmocka-dev"
 install="$pkgname.pre-install"


### PR DESCRIPTION
LMDB version in contrib/lmdb is 0.9.21, while the system lmdb is at
0.9.23 with some notable fixes. This change also avoids the need to
duplicate main/lmdb/cacheflush.patch to resolve the build on mips*.