### PR TITLE
main/dns-root-hints: do not mention tcely

### DIFF
--- a/main/dns-root-hints/APKBUILD
+++ b/main/dns-root-hints/APKBUILD
@@ -1,4 +1,3 @@
-# Contributor: tcely <dnshints-root+aports@tcely.33mail.com>
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=dns-root-hints
 pkgver=2019031302


### PR DESCRIPTION
This has been a hijacked package from the first commit.
I want nothing to do with this monstrous reinterpretation.
I am against everything about how this works.

We need a source of truth for our DNS software.
This is just more rot in the git repo like we had already.
The only goal that was met was to put the rot into fewer places.

Go read alpinelinux/aports#5950 and alpinelinux/aports#10039 instead.